### PR TITLE
Dynamic shape and compression for `tfds.features.Tensor`

### DIFF
--- a/tensorflow_datasets/core/features/__init__.py
+++ b/tensorflow_datasets/core/features/__init__.py
@@ -29,6 +29,7 @@ from tensorflow_datasets.core.features.feature import TensorInfo
 from tensorflow_datasets.core.features.features_dict import FeaturesDict
 from tensorflow_datasets.core.features.image_feature import Image
 from tensorflow_datasets.core.features.sequence_feature import Sequence
+from tensorflow_datasets.core.features.tensor_feature import Encoding
 from tensorflow_datasets.core.features.tensor_feature import Tensor
 from tensorflow_datasets.core.features.text_feature import Text
 from tensorflow_datasets.core.features.translation_feature import Translation

--- a/tensorflow_datasets/core/features/tensor_feature.py
+++ b/tensorflow_datasets/core/features/tensor_feature.py
@@ -15,6 +15,9 @@
 
 """Feature connector."""
 
+import enum
+from typing import Union
+
 import numpy as np
 import tensorflow.compat.v2 as tf
 
@@ -23,6 +26,27 @@ from tensorflow_datasets.core.features import feature as feature_lib
 
 Json = utils.Json
 Shape = utils.Shape
+
+
+class Encoding(enum.Enum):
+  """Encoding type of `tfds.features.Tensor`.
+
+  For higher dimension tensors, it is recommended to define the encoding as
+  zlib or bytes to save space on disk.
+
+  Attributes:
+    NONE: No compression (default). bools/integers will be upcasted to int64 as
+      this is the only integer format supported by the
+      [`tf.train.Example`](https://www.tensorflow.org/tutorials/load_data/tfrecord#tftrainexample)
+        protobufs in which examples are saved.
+    BYTES: Stored as raw bytes (avoid the upcasting from above).
+    ZLIB: The raw bytes are compressed using zlib.
+  """
+  NONE = 'none'
+  BYTES = 'bytes'
+  ZLIB = 'zlib'
+  # Could eventually add GZIP too (as supported by `tf.io.decode_compressed`
+  # but feel redundant with ZLIB.
 
 
 class Tensor(feature_lib.FeatureConnector):
@@ -37,29 +61,66 @@ class Tensor(feature_lib.FeatureConnector):
       *,
       shape: utils.Shape,
       dtype: tf.dtypes.DType,
+      # TODO(tfds): Could add an Encoding.AUTO to automatically compress
+      # tensors using some heuristic. However, careful about backward
+      # compatibility.
+      # Would require some `DatasetInfo.api_version = 1` which would be
+      # increased when triggering backward-incompatible changes.
+      encoding: Union[str, Encoding] = Encoding.NONE,
   ):
     """Construct a Tensor feature.
 
     Args:
       shape: Tensor shape
       dtype: Tensor dtype
+      encoding: Internal encoding. See `tfds.features.Encoding` for available
+        values.
     """
     self._shape = tuple(shape)
     self._dtype = dtype
+    if isinstance(encoding, str):
+      encoding = encoding.lower()
+    self._encoding = Encoding(encoding)
 
-  def get_tensor_info(self):
+    self._encoded_to_bytes = self._encoding != Encoding.NONE
+    self._dynamic_shape = self._shape.count(None) > 1
+
+    if self._dynamic_shape and not self._encoded_to_bytes:
+      raise ValueError('Multiple unknown dimensions Tensor require to set '
+                       "`Tensor(..., encoding='zlib')` (or 'bytes'). "
+                       f'For {self}')
+    if self._dtype == tf.string and self._encoded_to_bytes:
+      raise NotImplementedError(
+          'tfds.features.Tensor() does not support `encoding=` when '
+          'dtype=tf.string. Please open a PR if you need this feature.')
+
+  def get_tensor_info(self) -> feature_lib.TensorInfo:
     """See base class for details."""
     return feature_lib.TensorInfo(shape=self._shape, dtype=self._dtype)
 
-  def decode_batch_example(self, example_data):
+  def get_serialized_info(self):
     """See base class for details."""
-    # Overwrite the `tf.map_fn`, decoding is a no-op
-    return self.decode_example(example_data)
+    if self._encoded_to_bytes:  # Values encoded (stored as bytes)
+      serialized_spec = feature_lib.TensorInfo(shape=(), dtype=tf.string)
+    else:
+      serialized_spec = feature_lib.TensorInfo(
+          shape=self._shape,
+          dtype=self._dtype,
+      )
 
-  def decode_ragged_example(self, example_data):
-    """See base class for details."""
-    # Overwrite the `tf.map_fn`, decoding is a no-op
-    return self.decode_example(example_data)
+    # Dynamic shape, need an additional field to restore the shape after
+    # de-serialization.
+    if self._dynamic_shape:
+      return {
+          'shape':
+              feature_lib.TensorInfo(
+                  shape=(len(self._shape),),
+                  dtype=tf.int32,
+              ),
+          'value':
+              serialized_spec,
+      }
+    return serialized_spec
 
   def encode_example(self, example_data):
     """See base class for details."""
@@ -74,20 +135,78 @@ class Tensor(feature_lib.FeatureConnector):
     if example_data.dtype != np_dtype:
       raise ValueError('Dtype {} do not match {}'.format(
           example_data.dtype, np_dtype))
-    utils.assert_shape_match(example_data.shape, self._shape)
-    return example_data
+
+    shape = example_data.shape
+    utils.assert_shape_match(shape, self._shape)
+
+    # Eventually encode the data
+    if self._encoded_to_bytes:
+      example_data = example_data.tobytes()
+      # TODO(epot): Compress the bytes!!
+
+    # For dynamically shaped tensors, also save the shape (the proto
+    # flatten all values so we need a way to recover the shape).
+    if self._dynamic_shape:
+      return {
+          'value': example_data,
+          'shape': shape,
+      }
+    else:
+      return example_data
+
+  def decode_example(self, tfexample_data):
+    """See base class for details."""
+    if self._dynamic_shape:
+      value = tfexample_data['value']
+      # Extract the shape (while using static values when available)
+      shape = utils.merge_shape(tfexample_data['shape'], self._shape)
+    else:
+      value = tfexample_data
+      shape = tuple(-1 if dim is None else dim for dim in self._shape)
+
+    if self._encoded_to_bytes:
+      # TODO(epot): De-compress the bytes!!
+      value = tf.io.decode_raw(value, self._dtype)
+      value = tf.reshape(value, shape)
+
+    return value
+
+  def decode_batch_example(self, example_data):
+    """See base class for details."""
+    if self._dynamic_shape or self._encoded_to_bytes:
+      # For Sequence(Tensor()), use `tf.map_fn` to decode/reshape individual
+      # tensors.
+      return super().decode_batch_example(example_data)
+    else:
+      # For regular tensors, `decode_example` is a no-op so can be applied
+      # directly (avoid `tf.map_fn`)
+      return self.decode_example(example_data)
+
+  def decode_ragged_example(self, example_data):
+    """See base class for details."""
+    if self._dynamic_shape or self._encoded_to_bytes:
+      # For dynamic/bytes, we need to decode individual values, so call
+      # `tf.ragged.map_flat_values`
+      return super().decode_ragged_example(example_data)
+    else:
+      # For regular tensors, `decode_example` is a no-op so can be applied
+      # directly (avoid `tf.ragged.map_flat_values overhead`)
+      return self.decode_example(example_data)
 
   @classmethod
   def from_json_content(cls, value: Json) -> 'Tensor':
     return cls(
         shape=tuple(value['shape']),
         dtype=tf.dtypes.as_dtype(value['dtype']),
+        # Use .get for backward-compatibility
+        encoding=value.get('encoding', Encoding.NONE),
     )
 
   def to_json_content(self) -> Json:
     return {
         'shape': list(self._shape),
         'dtype': self._dtype.name,
+        'encoding': self._encoding.value,
     }
 
 

--- a/tensorflow_datasets/core/features/tensor_feature_test.py
+++ b/tensorflow_datasets/core/features/tensor_feature_test.py
@@ -16,16 +16,25 @@
 # coding=utf-8
 """Tests for tensorflow_datasets.core.features.tensor_feature."""
 
+from absl.testing import parameterized
 import numpy as np
+import pytest
 import tensorflow.compat.v2 as tf
 from tensorflow_datasets import testing
 from tensorflow_datasets.core import features as features_lib
 
 
-class FeatureTensorTest(testing.FeatureExpectationsTestCase):
+class FeatureTensorTest(
+    testing.FeatureExpectationsTestCase,
+    parameterized.TestCase,
+):
 
-  def test_shape_static(self):
-
+  @parameterized.parameters([
+      (features_lib.Encoding.NONE,),
+      (features_lib.Encoding.ZLIB,),
+      (features_lib.Encoding.BYTES,),
+  ])
+  def test_shape_static(self, encoding: features_lib.Encoding):
     np_input = np.random.rand(2, 3).astype(np.float32)
     array_input = [
         [1, 2, 3],
@@ -33,7 +42,11 @@ class FeatureTensorTest(testing.FeatureExpectationsTestCase):
     ]
 
     self.assertFeature(
-        feature=features_lib.Tensor(shape=(2, 3), dtype=tf.float32),
+        feature=features_lib.Tensor(
+            shape=(2, 3),
+            dtype=tf.float32,
+            encoding=encoding,
+        ),
         dtype=tf.float32,
         shape=(2, 3),
         tests=[
@@ -63,13 +76,21 @@ class FeatureTensorTest(testing.FeatureExpectationsTestCase):
         ],
     )
 
-  def test_shape_dynamic(self):
-
+  @parameterized.parameters([
+      (features_lib.Encoding.NONE,),
+      (features_lib.Encoding.ZLIB,),
+      (features_lib.Encoding.BYTES,),
+  ])
+  def test_shape_dynamic(self, encoding: features_lib.Encoding):
     np_input_dynamic_1 = np.random.randint(256, size=(2, 3, 2), dtype=np.int32)
     np_input_dynamic_2 = np.random.randint(256, size=(5, 3, 2), dtype=np.int32)
 
     self.assertFeature(
-        feature=features_lib.Tensor(shape=(None, 3, 2), dtype=tf.int32),
+        feature=features_lib.Tensor(
+            shape=(None, 3, 2),
+            dtype=tf.int32,
+            encoding=encoding,
+        ),
         dtype=tf.int32,
         shape=(None, 3, 2),
         tests=[
@@ -89,10 +110,126 @@ class FeatureTensorTest(testing.FeatureExpectationsTestCase):
             ),
         ])
 
-  def test_bool_flat(self):
+  @parameterized.parameters([
+      (features_lib.Encoding.NONE,),
+      (features_lib.Encoding.ZLIB,),
+      (features_lib.Encoding.BYTES,),
+  ])
+  def test_shape_dynamic_none_second(self, encoding: features_lib.Encoding):
+    np_input_dynamic_1 = np.random.randint(256, size=(3, 2, 2), dtype=np.int32)
+    np_input_dynamic_2 = np.random.randint(256, size=(3, 5, 2), dtype=np.int32)
 
     self.assertFeature(
-        feature=features_lib.Tensor(shape=(), dtype=tf.bool),
+        feature=features_lib.Tensor(
+            shape=(3, None, 2),  # None not at the first position.
+            dtype=tf.int32,
+            encoding=encoding,
+        ),
+        dtype=tf.int32,
+        shape=(3, None, 2),
+        tests=[
+            testing.FeatureExpectationItem(
+                value=np_input_dynamic_1,
+                expected=np_input_dynamic_1,
+            ),
+            testing.FeatureExpectationItem(
+                value=np_input_dynamic_2,
+                expected=np_input_dynamic_2,
+            ),
+            # Invalid shape
+            testing.FeatureExpectationItem(
+                value=np.random.randint(256, size=(2, 3, 1), dtype=np.int32),
+                raise_cls=ValueError,
+                raise_msg='are incompatible',
+            ),
+        ])
+
+  @parameterized.parameters([
+      # (features_lib.Encoding.NONE,),  # Multiple unknown dims requires bytes
+      (
+          features_lib.Encoding.ZLIB,),
+      (features_lib.Encoding.BYTES,),
+  ])
+  def test_features_shape_dynamic_multi_none(self,
+                                             encoding: features_lib.Encoding):
+    x = np.random.randint(256, size=(2, 3, 1), dtype=np.uint8)
+    x_other_shape = np.random.randint(256, size=(4, 4, 1), dtype=np.uint8)
+    wrong_shape = np.random.randint(256, size=(2, 3, 2), dtype=np.uint8)
+
+    self.assertFeature(
+        feature=features_lib.Tensor(
+            shape=(None, None, 1),
+            dtype=tf.uint8,
+            encoding=encoding,
+        ),
+        shape=(None, None, 1),
+        dtype=tf.uint8,
+        tests=[
+            testing.FeatureExpectationItem(
+                value=x,
+                expected=x,
+            ),
+            testing.FeatureExpectationItem(
+                value=x_other_shape,
+                expected=x_other_shape,
+            ),
+            testing.FeatureExpectationItem(
+                value=wrong_shape,  # Wrong shape
+                raise_cls=ValueError,
+                raise_msg='are incompatible',
+            ),
+        ],
+    )
+
+  @parameterized.parameters([
+      # NONE only support single unknown dim, not 2.
+      (features_lib.Encoding.BYTES, (2, None, 1)),
+      (features_lib.Encoding.ZLIB, (None, None, 1)),
+      (features_lib.Encoding.BYTES, (None, None, 1)),
+  ])
+  def test_features_multi_none_sequence(
+      self,
+      encoding: features_lib.Encoding,
+      shape,
+  ):
+    x = np.random.randint(256, size=(3, 2, 3, 1), dtype=np.uint8)
+    x_other_shape = np.random.randint(256, size=(3, 2, 2, 1), dtype=np.uint8)
+
+    self.assertFeature(
+        feature=features_lib.Sequence(
+            features_lib.Tensor(
+                shape=shape,
+                dtype=tf.uint8,
+                encoding=encoding,
+            ),),
+        shape=(None,) + shape,
+        dtype=tf.uint8,
+        tests=[
+            testing.FeatureExpectationItem(
+                value=x,
+                expected=x,
+            ),
+            testing.FeatureExpectationItem(
+                value=x_other_shape,
+                expected=x_other_shape,
+            ),
+            # TODO(epot): Is there a way to catch if the user try to encode
+            # tensors with different shapes ?
+        ],
+    )
+
+  @parameterized.parameters([
+      (features_lib.Encoding.NONE,),
+      (features_lib.Encoding.ZLIB,),
+      (features_lib.Encoding.BYTES,),
+  ])
+  def test_bool_flat(self, encoding: features_lib.Encoding):
+    self.assertFeature(
+        feature=features_lib.Tensor(
+            shape=(),
+            dtype=tf.bool,
+            encoding=encoding,
+        ),
         dtype=tf.bool,
         shape=(),
         tests=[
@@ -114,10 +251,18 @@ class FeatureTensorTest(testing.FeatureExpectationsTestCase):
             ),
         ])
 
-  def test_bool_array(self):
-
+  @parameterized.parameters([
+      (features_lib.Encoding.NONE,),
+      (features_lib.Encoding.ZLIB,),
+      (features_lib.Encoding.BYTES,),
+  ])
+  def test_bool_array(self, encoding: features_lib.Encoding):
     self.assertFeature(
-        feature=features_lib.Tensor(shape=(3,), dtype=tf.bool),
+        feature=features_lib.Tensor(
+            shape=(3,),
+            dtype=tf.bool,
+            encoding=encoding,
+        ),
         dtype=tf.bool,
         shape=(3,),
         tests=[
@@ -131,12 +276,20 @@ class FeatureTensorTest(testing.FeatureExpectationsTestCase):
             ),
         ])
 
-  def test_string(self):
+  @parameterized.parameters([
+      (features_lib.Encoding.NONE,),
+      # Bytes encoding not supported for tf.string
+  ])
+  def test_string(self, encoding: features_lib.Encoding):
     nonunicode_text = 'hello world'
     unicode_text = u'你好'
 
     self.assertFeature(
-        feature=features_lib.Tensor(shape=(), dtype=tf.string),
+        feature=features_lib.Tensor(
+            shape=(),
+            dtype=tf.string,
+            encoding=encoding,
+        ),
         shape=(),
         dtype=tf.string,
         tests=[
@@ -164,7 +317,11 @@ class FeatureTensorTest(testing.FeatureExpectationsTestCase):
     )
 
     self.assertFeature(
-        feature=features_lib.Tensor(shape=(2, 1), dtype=tf.string),
+        feature=features_lib.Tensor(
+            shape=(2, 1),
+            dtype=tf.string,
+            encoding=encoding,
+        ),
         shape=(2, 1),
         dtype=tf.string,
         tests=[
@@ -189,5 +346,18 @@ class FeatureTensorTest(testing.FeatureExpectationsTestCase):
     )
 
 
-if __name__ == '__main__':
-  testing.test_main()
+def test_invalid_input():
+  with pytest.raises(ValueError, match='Multiple unknown dimensions'):
+    features_lib.Tensor(
+        shape=(2, None, None),
+        dtype=tf.uint8,
+    )
+
+  with pytest.raises(
+      NotImplementedError,
+      match='does not support `encoding=` when dtype=tf.string'):
+    features_lib.Tensor(
+        shape=(2, 1),
+        dtype=tf.string,
+        encoding=features_lib.Encoding.BYTES,
+    )


### PR DESCRIPTION
* All FeatureConnector can now have a `None` dimension anywhere (previously restricted to the first position).
* `tfds.features.Tensor()` can have arbitrary number of dynamic dimension (`Tensor(..., shape=(None, None, 3, None))`)
* `tfds.features.Tensor` can now be serialised as bytes, instead of float/int values (to allow better compression): `Tensor(..., encoding='bytes')`
* Zlib compression mode coming in the child PR

PiperOrigin-RevId: 381089703

Thank you for your contribution!

Please read https://www.tensorflow.org/datasets/contribute#pr_checklist to make sure your PR follow the guidelines.

# Add Dataset

* Dataset Name: <name>
* Issue Reference: <link>
* `dataset_info.json` Gist: <link>
  
## Description

<description>
  
## Checklist
* [ ] Address all TODO's
* [ ] Add alphabetized import to subdirectory's `__init__.py`
* [ ] Run `download_and_prepare` successfully
* [ ] Add [checksums file](https://www.tensorflow.org/datasets/add_dataset#2_run_download_and_prepare_locally)
* [ ] Properly cite in `BibTeX` format
* [ ] Add passing test(s)
* [ ] Add test data
* [ ] If using additional dependencies (e.g. `scipy`), use [lazy_imports](https://www.tensorflow.org/datasets/add_dataset#extra_dependencies) (if applicable)
* [ ] Add data generation script (if applicable)
* [ ] [Lint](https://www.tensorflow.org/datasets/add_dataset#5_check_your_code_style) code
